### PR TITLE
rewrite fish_prompt.fish because source command did not work

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -1,2 +1,0 @@
-# name: random
-source $OMF_PATH/themes/(random choice (ls $OMF_PATH/themes/))/functions/fish_prompt.fish

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -1,16 +1,13 @@
 #!/usr/bin/env fish
 
 
-# name: random
-
-
 function fish_prompt
 ## themes in omf could not used by source command
 ## source $OMF_PATH/themes/$theme_to_enable/functions/fish_prompt.fish
 
 
-## workaround for priority of fish_prompt.fish . It cause omf theme command fail.
-
+## workaround for priority of fish_prompt.fish . It cause omf theme command fail. 
+## omf theme this script file will not call rm command to fix the issue.
 	if test -e (omf.xdg.config_home)/fish/functions/fish_prompt.fish
 	rm (omf.xdg.config_home)/fish/functions/fish_prompt.fish 
 	end
@@ -24,13 +21,22 @@ function fish_prompt
 		break
 		end
 	end
-	end
+	end	
 
 
 ## enable new theme
-	omf.cli.theme $theme_to_enable
+	omf.theme.set $theme_to_enable
+	
 
+	## force omf to enable a new theme when fish source dotfiles (i.e. omf reload)
+	printf "random_omf_theme" > $OMF_CONFIG/theme
+	
+	
+	## pwd command makes a new prompt line that fix prompt line disappeared after enabling new theme.
+	pwd
+	## omf reload command will cause dead loop. It can now refresh prompt line.
+	##omf.cli.reload
 
-## fix prompt disappeared after enabling new theme.  
-	omf.cli.reload
+	
+## function fish_prompt end	
 end

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -16,7 +16,7 @@ function fish_prompt
 	end
 
 
- ## pickup a theme_to_enable from omf official repo
+## pickup a theme_to_enable from omf official repo
 	while true
 	set theme_to_enable (random choice (omf.index.query --type=theme ))
 	if test "random" != $theme_to_enable

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -1,0 +1,36 @@
+#!/usr/bin/env fish
+
+
+# name: random
+
+
+function fish_prompt
+## themes in omf could not used by source command
+## source $OMF_PATH/themes/$theme_to_enable/functions/fish_prompt.fish
+
+
+## workaround for priority of fish_prompt.fish . It cause omf theme command fail.
+
+	if test -e (omf.xdg.config_home)/fish/functions/fish_prompt.fish
+	rm (omf.xdg.config_home)/fish/functions/fish_prompt.fish 
+	end
+
+
+ ## pickup a theme_to_enable from omf official repo
+	while true
+	set theme_to_enable (random choice (omf.index.query --type=theme ))
+	if test "random" != $theme_to_enable
+		if test "random_omf_theme" != $theme_to_enable
+		break
+		end
+	end
+	end
+
+
+## enable new theme
+	omf.cli.theme $theme_to_enable
+
+
+## fix prompt disappeared after enabling new theme.  
+	omf.cli.reload
+end


### PR DESCRIPTION
Hello.  
I have tried this theme but it failed. To enable a theme, we have to source all the `.fish` files in the theme directory.  Please read this source code of function [omf.thme.set](https://github.com/oh-my-fish/oh-my-fish/blob/90f875e02dbb63a7e12430ceb034206bea278c28/pkg/omf/functions/themes/omf.theme.set.fish#L22).

Then I made a new theme. Please review it.  
Best Wishes.